### PR TITLE
Fix ValueError: Attempted relative import in non-package

### DIFF
--- a/site_scons/hboot_image_compiler/hboot_image.py
+++ b/site_scons/hboot_image_compiler/hboot_image.py
@@ -37,9 +37,9 @@ import xml.dom.minidom
 import xml.etree.ElementTree
 
 import elf_support
-from . import option_compiler
-from . import patch_definitions
-from . import snippet_library
+import option_compiler
+import patch_definitions
+import snippet_library
 
 
 class ResolveDefines(ast.NodeTransformer):


### PR DESCRIPTION
from . import xxx leads to the error:

from . import option_compiler
ValueError: Attempted relative import in non-package

Changing this back to simple imports let the python2 tests
run again.